### PR TITLE
Add initial Elixir microservice skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DB_NAME=job_hunt_dev
+DB_USER=postgres
+DB_PASS=postgres
+DB_HOST=db
+PORT=4000
+LINKEDIN_COOKIE=
+GLASSDOOR_COOKIE=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/_build
+/dep
+/deps
+erl_crash.dump
+*.ez
+*.beam
+*.plt
+.vscode
+.env
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM elixir:1.16-alpine AS build
+WORKDIR /app
+COPY mix.exs mix.lock ./
+COPY config ./config
+RUN mix local.hex --force && \
+    mix local.rebar --force && \
+    mix deps.get --only prod
+COPY lib ./lib
+COPY priv ./priv
+RUN MIX_ENV=prod mix release
+
+FROM alpine:3.18 AS app
+WORKDIR /app
+RUN apk add --no-cache bash openssl ncurses-libs
+COPY --from=build /app/_build/prod/rel/job_hunt ./
+CMD ["./bin/job_hunt", "start"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# jsearch-microservice
+# JobHunt Microservice
+
+This service aggregates job postings from multiple sources and exposes a simple REST API.
+
+## Development
+
+```bash
+git clone <repo_url>
+cd jsearch-microservice
+cp .env.example .env
+# edit .env with your DB credentials and cookies
+docker compose up --build
+```
+
+Once running, query:
+
+```
+curl http://localhost:4000/jobs?keyword=elixir
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,25 @@
+import Config
+
+config :job_hunt, ecto_repos: [JobHunt.Repo]
+
+config :job_hunt, JobHunt.Repo,
+  database: System.get_env("DB_NAME", "job_hunt_dev"),
+  username: System.get_env("DB_USER", "postgres"),
+  password: System.get_env("DB_PASS", "postgres"),
+  hostname: System.get_env("DB_HOST", "db"),
+  pool_size: 10
+
+config :logger, backends: [LoggerJSON]
+
+config :job_hunt, JobHuntWeb.Router,
+  port: String.to_integer(System.get_env("PORT" || "4000"))
+
+config :job_hunt, JobHunt.Scheduler,
+  timezone: "Etc/UTC"
+
+import_config "releases.exs"
+
+config :job_hunt, JobHunt.Scheduler,
+  jobs: [
+    {"@hourly", {JobHunt.Aggregator, :fetch_all, [%{}]}}
+  ]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,11 @@
+import Config
+
+config :job_hunt, JobHunt.Repo,
+  database: "job_hunt_dev",
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+config :job_hunt, JobHuntWeb.Router, port: 4000

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,11 @@
+import Config
+
+config :job_hunt, JobHunt.Repo,
+  database: System.fetch_env!("DB_NAME"),
+  username: System.fetch_env!("DB_USER"),
+  password: System.fetch_env!("DB_PASS"),
+  hostname: System.fetch_env!("DB_HOST"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE" || "10"))
+
+config :job_hunt, JobHuntWeb.Router,
+  port: String.to_integer(System.fetch_env!("PORT"))

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,0 +1,11 @@
+import Config
+
+config :job_hunt, JobHunt.Repo,
+  database: System.fetch_env!("DB_NAME"),
+  username: System.fetch_env!("DB_USER"),
+  password: System.fetch_env!("DB_PASS"),
+  hostname: System.fetch_env!("DB_HOST"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE" || "10"))
+
+config :job_hunt, JobHuntWeb.Router,
+  port: String.to_integer(System.fetch_env!("PORT"))

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,11 @@
+import Config
+
+config :job_hunt, JobHunt.Repo,
+  database: "job_hunt_test",
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 10
+
+config :logger, level: :warn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: ${DB_NAME:-job_hunt_dev}
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASS:-postgres}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+
+  app:
+    build: .
+    environment:
+      DB_NAME: ${DB_NAME:-job_hunt_dev}
+      DB_USER: ${DB_USER:-postgres}
+      DB_PASS: ${DB_PASS:-postgres}
+      DB_HOST: db
+      PORT: ${PORT:-4000}
+      LINKEDIN_COOKIE: ${LINKEDIN_COOKIE}
+      GLASSDOOR_COOKIE: ${GLASSDOOR_COOKIE}
+    depends_on:
+      - db
+    ports:
+      - '4000:4000'
+
+volumes:
+  db_data:

--- a/lib/job_hunt/aggregator.ex
+++ b/lib/job_hunt/aggregator.ex
@@ -1,0 +1,75 @@
+defmodule JobHunt.Aggregator do
+  @moduledoc """
+  Fetches jobs from multiple sources and filters them.
+  """
+
+  @behaviour JobHunt.Sources
+  alias JobHunt.Sources
+
+  @keywords ["Web Developer", "Software Engineer", "Elixir", "Ruby", "React", "Angular", "JavaScript", "CSS", "GitHub", "AI"]
+  @nashville {36.1627, -86.7816}
+  @radius_mi 50
+
+  @sources [
+    JobHunt.Sources.LinkedIn,
+    JobHunt.Sources.Indeed,
+    JobHunt.Sources.Glassdoor,
+    JobHunt.Sources.GitHub
+  ]
+
+  def fetch_all(query) do
+    @sources
+    |> Enum.flat_map(fn source ->
+      with {:module, _} <- Code.ensure_loaded(source) do
+        source.fetch(query)
+      else
+        _ -> []
+      end
+    end)
+    |> filter(query)
+  end
+
+  def filter(raw_jobs, query) do
+    raw_jobs
+    |> Enum.map(&normalise/1)
+    |> Enum.filter(&meets_constraints?(&1, query))
+  end
+
+  defp normalise(job) do
+    job
+    |> Map.update(:salary, nil, &parse_salary/1)
+    |> Map.update(:remote, false, &(&1 in [true, "true", "yes"]))
+    |> Map.update(:location, nil, &geocode/1)
+  end
+
+  defp parse_salary(nil), do: nil
+  defp parse_salary(s) when is_binary(s) do
+    s
+    |> String.replace(~r/[^\d]/, "")
+    |> case do
+      <<>> -> nil
+      digits -> String.to_integer(digits)
+    end
+  end
+
+  defp geocode(location) when is_binary(location), do: location
+  defp geocode(loc), do: loc
+
+  defp meets_constraints?(job, query) do
+    salary_ok?(job.salary) and
+      remote_or_within_radius?(job.remote, job.location) and
+      keyword_ok?(job.title, query[:keyword])
+  end
+
+  defp salary_ok?(salary), do: salary && salary >= 110_000
+
+  defp remote_or_within_radius?(true, _loc), do: true
+  defp remote_or_within_radius?(_, nil), do: false
+  defp remote_or_within_radius?(_, _loc), do: true
+
+  defp keyword_ok?(title, nil), do: keyword_ok?(title, "")
+  defp keyword_ok?(title, kw) do
+    text = String.downcase(title <> " " <> kw)
+    Enum.any?(@keywords, fn word -> String.contains?(text, String.downcase(word)) end)
+  end
+end

--- a/lib/job_hunt/application.ex
+++ b/lib/job_hunt/application.ex
@@ -1,0 +1,21 @@
+defmodule JobHunt.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      JobHunt.Repo,
+      {Registry, keys: :unique, name: JobHunt.WorkerRegistry},
+      {JobHunt.Worker, :linkedin},
+      {JobHunt.Worker, :indeed},
+      {JobHunt.Worker, :glassdoor},
+      {JobHunt.Worker, :github},
+      {Bandit, plug: JobHuntWeb.Router, scheme: :http, port: Application.get_env(:job_hunt, JobHuntWeb.Router)[:port]},
+      JobHunt.Scheduler
+    ]
+
+    opts = [strategy: :one_for_one, name: JobHunt.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/job_hunt/jobs/job.ex
+++ b/lib/job_hunt/jobs/job.ex
@@ -1,0 +1,24 @@
+defmodule JobHunt.Jobs.Job do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "jobs" do
+    field :job_id, :string
+    field :title, :string
+    field :company, :string
+    field :location, :string
+    field :salary, :integer
+    field :remote, :boolean, default: false
+    field :url, :string
+    field :description, :string
+
+    timestamps()
+  end
+
+  def changeset(job, attrs) do
+    job
+    |> cast(attrs, [:job_id, :title, :company, :location, :salary, :remote, :url, :description])
+    |> validate_required([:job_id, :title, :company])
+    |> unique_constraint(:job_id)
+  end
+end

--- a/lib/job_hunt/prom_ex.ex
+++ b/lib/job_hunt/prom_ex.ex
@@ -1,0 +1,9 @@
+defmodule JobHunt.PromEx do
+  use PromEx, otp_app: :job_hunt
+
+  @impl true
+def plugins, do: []
+
+  @impl true
+def dashboards, do: []
+end

--- a/lib/job_hunt/repo.ex
+++ b/lib/job_hunt/repo.ex
@@ -1,0 +1,5 @@
+defmodule JobHunt.Repo do
+  use Ecto.Repo,
+    otp_app: :job_hunt,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/lib/job_hunt/scheduler.ex
+++ b/lib/job_hunt/scheduler.ex
@@ -1,0 +1,3 @@
+defmodule JobHunt.Scheduler do
+  use Quantum, otp_app: :job_hunt
+end

--- a/lib/job_hunt/sources.ex
+++ b/lib/job_hunt/sources.ex
@@ -1,0 +1,3 @@
+defmodule JobHunt.Sources do
+  @callback fetch(map()) :: [%{optional(atom()) => any()}]
+end

--- a/lib/job_hunt/sources/github.ex
+++ b/lib/job_hunt/sources/github.ex
@@ -1,0 +1,8 @@
+defmodule JobHunt.Sources.GitHub do
+  @behaviour JobHunt.Sources
+
+  @impl true
+  def fetch(_query) do
+    []
+  end
+end

--- a/lib/job_hunt/sources/glassdoor.ex
+++ b/lib/job_hunt/sources/glassdoor.ex
@@ -1,0 +1,8 @@
+defmodule JobHunt.Sources.Glassdoor do
+  @behaviour JobHunt.Sources
+
+  @impl true
+  def fetch(_query) do
+    []
+  end
+end

--- a/lib/job_hunt/sources/indeed.ex
+++ b/lib/job_hunt/sources/indeed.ex
@@ -1,0 +1,8 @@
+defmodule JobHunt.Sources.Indeed do
+  @behaviour JobHunt.Sources
+
+  @impl true
+  def fetch(_query) do
+    []
+  end
+end

--- a/lib/job_hunt/sources/linkedin.ex
+++ b/lib/job_hunt/sources/linkedin.ex
@@ -1,0 +1,9 @@
+defmodule JobHunt.Sources.LinkedIn do
+  @behaviour JobHunt.Sources
+
+  @impl true
+  def fetch(_query) do
+    # Implementation placeholder
+    []
+  end
+end

--- a/lib/job_hunt/worker.ex
+++ b/lib/job_hunt/worker.ex
@@ -1,0 +1,42 @@
+defmodule JobHunt.Worker do
+  use GenServer
+  require Logger
+
+  alias JobHunt.Aggregator
+  alias JobHunt.Repo
+  alias JobHunt.Jobs.Job
+
+  @refresh_intervals %{
+    linkedin: 21_600,
+    indeed: 21_600,
+    glassdoor: 86_400,
+    github: 86_400
+  }
+
+  def start_link(source) do
+    GenServer.start_link(__MODULE__, source, name: via_tuple(source))
+  end
+
+  def via_tuple(source) do
+    {:via, Registry, {JobHunt.WorkerRegistry, source}}
+  end
+
+  @impl true
+  def init(source) do
+    schedule_work(source)
+    {:ok, source}
+  end
+
+  @impl true
+  def handle_info(:work, source) do
+    Logger.info("fetching #{source}")
+    Aggregator.fetch_all(%{source: source})
+    schedule_work(source)
+    {:noreply, source}
+  end
+
+  defp schedule_work(source) do
+    interval = Map.get(@refresh_intervals, source, 86_400)
+    Process.send_after(self(), :work, interval * 1000)
+  end
+end

--- a/lib/job_hunt/worker_registry.ex
+++ b/lib/job_hunt/worker_registry.ex
@@ -1,0 +1,5 @@
+defmodule JobHunt.WorkerRegistry do
+  use Registry,
+    keys: :unique,
+    name: __MODULE__
+end

--- a/lib/job_hunt_web/router.ex
+++ b/lib/job_hunt_web/router.ex
@@ -1,0 +1,22 @@
+defmodule JobHuntWeb.Router do
+  use Plug.Router
+  use PromEx.Plug, prom_ex_module: JobHunt.PromEx
+
+  plug :match
+  plug :dispatch
+
+  get "/health" do
+    send_resp(conn, 200, "OK")
+  end
+
+  get "/jobs" do
+    keyword = get_in(conn.params, ["keyword"]) || ""
+    remote_only = conn.params["remote_only"] == "true"
+    jobs = JobHunt.Aggregator.fetch_all(%{keyword: keyword, remote_only: remote_only})
+    send_resp(conn, 200, Jason.encode!(jobs))
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not found")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,42 @@
+defmodule JobHunt.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :job_hunt,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      compilers: Mix.compilers(),
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {JobHunt.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      {:tesla, "~> 1.7"},
+      {:finch, "~> 0.17"},
+      {:floki, "~> 0.36"},
+      {:broadway, "~> 1.0"},
+      {:ecto_sql, "~> 3.11"},
+      {:postgrex, ">= 0.0.0"},
+      {:bandit, "~> 0.8"},
+      {:jason, "~> 1.4"},
+      {:quantum, "~> 3.0"},
+      {:logger_json, "~> 5.0"},
+      {:prom_ex, "~> 1.9"},
+      {:mox, "~> 1.0", only: :test}
+    ]
+  end
+end

--- a/priv/repo/migrations/20240617120000_create_jobs.exs
+++ b/priv/repo/migrations/20240617120000_create_jobs.exs
@@ -1,0 +1,20 @@
+defmodule JobHunt.Repo.Migrations.CreateJobs do
+  use Ecto.Migration
+
+  def change do
+    create table(:jobs) do
+      add :job_id, :string, null: false
+      add :title, :string, null: false
+      add :company, :string, null: false
+      add :location, :string
+      add :salary, :integer
+      add :remote, :boolean, default: false
+      add :url, :string
+      add :description, :text
+
+      timestamps()
+    end
+
+    create unique_index(:jobs, [:job_id])
+  end
+end

--- a/test/job_hunt/aggregator_test.exs
+++ b/test/job_hunt/aggregator_test.exs
@@ -1,0 +1,15 @@
+defmodule JobHunt.AggregatorTest do
+  use ExUnit.Case, async: true
+
+  alias JobHunt.Aggregator
+
+  test "filters by salary" do
+    jobs = [%{salary: 120_000, title: "Elixir Dev"}, %{salary: 90_000}]
+    assert [%{salary: 120_000, title: "Elixir Dev"}] = Aggregator.filter(jobs, %{})
+  end
+
+  test "rejects when keyword missing" do
+    jobs = [%{salary: 120_000, title: "Unrelated"}]
+    assert [] = Aggregator.filter(jobs, %{keyword: "Elixir"})
+  end
+end

--- a/test/job_hunt/sources/github_test.exs
+++ b/test/job_hunt/sources/github_test.exs
@@ -1,0 +1,9 @@
+defmodule JobHunt.Sources.GitHubTest do
+  use ExUnit.Case, async: true
+
+  alias JobHunt.Sources.GitHub
+
+  test "fetch returns empty list" do
+    assert [] = GitHub.fetch(%{})
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,3 @@
+ExUnit.start()
+Mox.defmock(JobHunt.HttpMock, for: Tesla.Adapter)
+Application.put_env(:tesla, :adapter, JobHunt.HttpMock)


### PR DESCRIPTION
## Summary
- scaffold JobHunt Elixir app with Plug and Bandit
- add aggregator behaviour and source modules
- define Ecto Repo and job schema with migration
- wire up minimal Plug router
- provide Dockerfile and compose setup
- supply basic tests and example env file

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4b4489dc833199842f194e361519