### PR TITLE
Add Dotenvy for .env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The application reads its configuration from environment variables. A sample fil
 cp .env.example .env
 ```
 
+When the application starts it will automatically load variables from `.env`
+using the [Dotenvy](https://hex.pm/packages/dotenvy) library.
+
 Open `.env` in your favourite editor and review the settings. By default the database credentials match the ones used by the `docker-compose.yml` file. You may also want to provide any authentication cookies for the job sites you intend to scrape.
 
 ## Starting the containers

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,10 @@
 import Config
 
+# Load environment variables from .env when present
+if File.exists?(Path.expand("../.env", __DIR__)) do
+  Dotenvy.load()
+end
+
 config :job_hunt, ecto_repos: [JobHunt.Repo]
 
 config :job_hunt, JobHunt.Repo,

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule JobHunt.MixProject do
       {:quantum, "~> 3.0"},
       {:logger_json, "~> 5.0"},
       {:prom_ex, "~> 1.9"},
-      {:mox, "~> 1.0", only: :test}
+      {:mox, "~> 1.0", only: :test},
+      {:dotenvy, "~> 0.8"}
     ]
   end
 end


### PR DESCRIPTION
## Summary
- include `dotenvy` dependency
- load `.env` via Dotenvy during config
- document Dotenvy usage in README

## Testing
- *(fails: `mix` not available)*

------
https://chatgpt.com/codex/tasks/task_e_685c8abac1ec8331b2910ec973a4d015