### PR TITLE
Fix docker build missing env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM elixir:1.16-alpine AS build
 WORKDIR /app
+ENV DB_NAME=job_hunt_prod \
+    DB_USER=postgres \
+    DB_PASS=postgres \
+    DB_HOST=localhost \
+    PORT=4000
 COPY mix.exs mix.lock ./
 COPY config ./config
 RUN mix local.hex --force && \

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,9 @@ config :job_hunt, JobHuntWeb.Router,
 config :job_hunt, JobHunt.Scheduler,
   timezone: "Etc/UTC"
 
-import_config "releases.exs"
+if config_env() == :prod do
+  import_config "releases.exs"
+end
 
 config :job_hunt, JobHunt.Scheduler,
   jobs: [


### PR DESCRIPTION
## Summary
- only import production release config in production
- provide default environment vars during Docker build

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c8c1842508331ac163b1becd510d6