### PR TITLE
Fix PromEx plug usage

### DIFF
--- a/lib/job_hunt_web/router.ex
+++ b/lib/job_hunt_web/router.ex
@@ -1,6 +1,6 @@
 defmodule JobHuntWeb.Router do
   use Plug.Router
-  use PromEx.Plug, prom_ex_module: JobHunt.PromEx
+  plug PromEx.Plug, prom_ex_module: JobHunt.PromEx
 
   plug :match
   plug :dispatch


### PR DESCRIPTION
## Summary
- fix JobHuntWeb router to use PromEx.Plug as a `plug`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_685c8e787b00833184c04bf0a76675df