### PR TITLE
Fix compile failure and remove unused registry

### DIFF
--- a/lib/job_hunt/aggregator.ex
+++ b/lib/job_hunt/aggregator.ex
@@ -4,11 +4,7 @@ defmodule JobHunt.Aggregator do
   """
 
   @behaviour JobHunt.Sources
-  alias JobHunt.Sources
-
   @keywords ["Web Developer", "Software Engineer", "Elixir", "Ruby", "React", "Angular", "JavaScript", "CSS", "GitHub", "AI"]
-  @nashville {36.1627, -86.7816}
-  @radius_mi 50
 
   @sources [
     JobHunt.Sources.LinkedIn,

--- a/lib/job_hunt/worker_registry.ex
+++ b/lib/job_hunt/worker_registry.ex
@@ -1,5 +1,0 @@
-defmodule JobHunt.WorkerRegistry do
-  use Registry,
-    keys: :unique,
-    name: __MODULE__
-end


### PR DESCRIPTION
## Summary
- remove unused `JobHunt.WorkerRegistry` module that caused a compile error
- clean up `JobHunt.Aggregator` to remove unused alias and attributes

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c8f6af0c083319244d48d800e317f