### PR TITLE
Fix missing C++ libs for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN MIX_ENV=prod mix release
 
 FROM alpine:3.18 AS app
 WORKDIR /app
-RUN apk add --no-cache bash openssl ncurses-libs
+# The Erlang runtime shipped in the release requires libgcc and libstdc++
+# which are not part of a minimal Alpine image. Install them alongside
+# other runtime dependencies so the application can start successfully.
+RUN apk add --no-cache bash openssl ncurses-libs libstdc++ libgcc
 COPY --from=build /app/_build/prod/rel/job_hunt ./
 CMD ["./bin/job_hunt", "start"]


### PR DESCRIPTION
## Summary
- install libstdc++ and libgcc in the runtime Docker image

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c93c31ea88331a20c215c798849b9