### PR TITLE
Fix duplicate worker supervision

### DIFF
--- a/lib/job_hunt/worker.ex
+++ b/lib/job_hunt/worker.ex
@@ -2,6 +2,17 @@ defmodule JobHunt.Worker do
   use GenServer
   require Logger
 
+  @impl true
+  def child_spec(source) do
+    %{
+      id: {__MODULE__, source},
+      start: {__MODULE__, :start_link, [source]},
+      restart: :permanent,
+      shutdown: 500,
+      type: :worker
+    }
+  end
+
   alias JobHunt.Aggregator
   alias JobHunt.Repo
   alias JobHunt.Jobs.Job


### PR DESCRIPTION
## Summary
- avoid duplicate Worker child specs by adding custom `child_spec/1`

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c94b1b058833194f07c0fa0c737bf