### PR TITLE
Fix Bandit configuration

### DIFF
--- a/lib/job_hunt/application.ex
+++ b/lib/job_hunt/application.ex
@@ -15,7 +15,7 @@ defmodule JobHunt.Application do
        plug: JobHuntWeb.Router,
        scheme: :http,
        port: Application.get_env(:job_hunt, JobHuntWeb.Router)[:port],
-       transport_options: [read_timeout: Application.get_env(:job_hunt, JobHuntWeb.Router)[:read_timeout]]},
+       read_timeout: Application.get_env(:job_hunt, JobHuntWeb.Router)[:read_timeout]},
       JobHunt.Scheduler
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule JobHunt.MixProject do
       {:broadway, "~> 1.0"},
       {:ecto_sql, "~> 3.11"},
       {:postgrex, ">= 0.0.0"},
-      {:bandit, "~> 1.6"},
+      {:bandit, "~> 1.7"},
       {:jason, "~> 1.4"},
       {:quantum, "~> 3.0"},
       {:logger_json, "~> 5.0"},


### PR DESCRIPTION
## Summary
- update Bandit dependency to `~> 1.7`
- set `read_timeout` directly when starting Bandit

## Testing
- `mix format` *(fails: `mix: command not found`)*
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cacee1d688331b1aa5a83d1bf970e