### PR TITLE
Fix Cowboy read_timeout startup crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ using the [Dotenvy](https://hex.pm/packages/dotenvy) library.
 
 Open `.env` in your favourite editor and review the settings. By default the database credentials match the ones used by the `docker-compose.yml` file. You may also want to provide any authentication cookies for the job sites you intend to scrape.
 
-The `COWBOY_READ_TIMEOUT` variable controls how long the server waits for
-clients to send HTTP headers. If your clients connect slowly you can increase
-this value (in milliseconds) to avoid timeouts. The `.env.example` file sets it
-to `120000` (two minutes).
+The `COWBOY_READ_TIMEOUT` variable controls the Cowboy `request_timeout`
+(in milliseconds). It determines how long the server waits for clients to send
+HTTP headers. If your clients connect slowly you can increase this value to
+avoid timeouts. The `.env.example` file sets it to `120000` (two minutes).
 
 ## Starting the containers
 

--- a/lib/job_hunt/application.ex
+++ b/lib/job_hunt/application.ex
@@ -16,7 +16,10 @@ defmodule JobHunt.Application do
        plug: JobHuntWeb.Router,
        options: [
          port: Application.get_env(:job_hunt, JobHuntWeb.Router)[:port],
-         read_timeout: Application.get_env(:job_hunt, JobHuntWeb.Router)[:read_timeout]
+         protocol_options: [
+           request_timeout:
+             Application.get_env(:job_hunt, JobHuntWeb.Router)[:read_timeout]
+         ]
        ]},
       JobHunt.Scheduler
     ]


### PR DESCRIPTION
## Summary
- fix Cowboy options so request timeout is configured correctly
- clarify README about the timeout setting

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cb06f649c83318335d8a913ee3185