### PR TITLE
Fix remote filtering and add GitHub sample source

### DIFF
--- a/lib/job_hunt/aggregator.ex
+++ b/lib/job_hunt/aggregator.ex
@@ -22,7 +22,7 @@ defmodule JobHunt.Aggregator do
         _ -> []
       end
     end)
-    |> filter(query)
+      |> filter(query)
   end
 
   def filter(raw_jobs, query) do
@@ -53,15 +53,16 @@ defmodule JobHunt.Aggregator do
 
   defp meets_constraints?(job, query) do
     salary_ok?(job.salary) and
-      remote_or_within_radius?(job.remote, job.location) and
+      remote_or_within_radius?(job.remote, job.location, query[:remote_only]) and
       keyword_ok?(job.title, query[:keyword])
   end
 
   defp salary_ok?(salary), do: salary && salary >= 110_000
 
-  defp remote_or_within_radius?(true, _loc), do: true
-  defp remote_or_within_radius?(_, nil), do: false
-  defp remote_or_within_radius?(_, _loc), do: true
+  defp remote_or_within_radius?(true, _loc, _remote_only), do: true
+  defp remote_or_within_radius?(_, _loc, true), do: false
+  defp remote_or_within_radius?(_, nil, _), do: false
+  defp remote_or_within_radius?(_, _loc, _), do: true
 
   defp keyword_ok?(title, nil), do: keyword_ok?(title, "")
   defp keyword_ok?(title, kw) do

--- a/lib/job_hunt/sources/github.ex
+++ b/lib/job_hunt/sources/github.ex
@@ -2,7 +2,24 @@ defmodule JobHunt.Sources.GitHub do
   @behaviour JobHunt.Sources
 
   @impl true
-  def fetch(_query) do
-    []
+  def fetch(query) do
+    job = %{
+      job_id: "gh_1",
+      title: "Elixir Developer",
+      company: "GitHub",
+      location: "Remote",
+      salary: "$120000",
+      remote: true,
+      url: "https://example.com/jobs/gh_1",
+      description: "Work on open source projects"
+    }
+
+    keyword = String.downcase(to_string(query[:keyword] || ""))
+
+    if String.contains?(String.downcase(job.title), keyword) do
+      [job]
+    else
+      []
+    end
   end
 end

--- a/test/job_hunt/aggregator_test.exs
+++ b/test/job_hunt/aggregator_test.exs
@@ -12,4 +12,14 @@ defmodule JobHunt.AggregatorTest do
     jobs = [%{salary: 120_000, title: "Unrelated"}]
     assert [] = Aggregator.filter(jobs, %{keyword: "Elixir"})
   end
+
+  test "filters out non-remote jobs when remote_only is true" do
+    jobs = [
+      %{salary: 120_000, title: "Elixir Dev", remote: false, location: "NY"},
+      %{salary: 120_000, title: "Remote Elixir", remote: true}
+    ]
+
+    results = Aggregator.filter(jobs, %{remote_only: true})
+    assert [%{title: "Remote Elixir"}] = results
+  end
 end

--- a/test/job_hunt/sources/github_test.exs
+++ b/test/job_hunt/sources/github_test.exs
@@ -3,7 +3,8 @@ defmodule JobHunt.Sources.GitHubTest do
 
   alias JobHunt.Sources.GitHub
 
-  test "fetch returns empty list" do
-    assert [] = GitHub.fetch(%{})
+  test "fetch returns a matching job" do
+    [%{title: title}] = GitHub.fetch(%{keyword: "elixir"})
+    assert String.contains?(String.downcase(title), "elixir")
   end
 end


### PR DESCRIPTION
## Summary
- implement `remote_only` filtering in aggregator
- add a basic GitHub source returning a demo job
- update aggregator and GitHub source unit tests

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb366a9ac8331bff1eea47bf4ae57